### PR TITLE
cfns: fix mismatch in gnu_inline attributes

### DIFF
--- a/gcc/cp/cfns.gperf
+++ b/gcc/cp/cfns.gperf
@@ -22,6 +22,9 @@ __inline
 static unsigned int hash (const char *, unsigned int);
 #ifdef __GNUC__
 __inline
+#ifdef __GNUC_STDC_INLINE__
+__attribute__ ((__gnu_inline__))
+#endif
 #endif
 const char * libc_name_p (const char *, unsigned int);
 %}

--- a/gcc/cp/cfns.h
+++ b/gcc/cp/cfns.h
@@ -53,6 +53,9 @@ __inline
 static unsigned int hash (const char *, unsigned int);
 #ifdef __GNUC__
 __inline
+#ifdef __GNUC_STDC_INLINE__
+__attribute__ ((__gnu_inline__))
+#endif
 #endif
 const char * libc_name_p (const char *, unsigned int);
 /* maximum key range = 391, duplicates = 0 */


### PR DESCRIPTION
I had issues compiling the HermitCore GCC (5.3) with the new host GCC 6.1. I found a patch online that solves this: https://gcc.gnu.org/ml/gcc-patches/2015-08/msg00375.html

I don't have the permissions to push directly, that's why I opened a PR. Please don't forget to point the HermitCore submodule to the new commit after merging.
